### PR TITLE
Add HiDPI/retina display support

### DIFF
--- a/src/clay/init.c
+++ b/src/clay/init.c
@@ -25,7 +25,7 @@ bool clay_init(AppState *state) {
         return false;
 
     int width, height;
-    SDL_GetWindowSize(state->window, &width, &height);
+    SDL_GetWindowSizeInPixels(state->window, &width, &height);
     Clay_Initialize(clayMemory, (Clay_Dimensions) { (float) width, (float) height }, (Clay_ErrorHandler) { HandleClayErrors });
     Clay_SetMeasureTextFunction(SDL_MeasureText, &state->rendererData);
 

--- a/src/display/scale.h
+++ b/src/display/scale.h
@@ -5,19 +5,26 @@
 #include "../state.h"
 #include "../text/buffer.h"
 
+static inline void ui_recompute_scale(AppState *state) {
+    state->ui.scale_factor = state->ui.dpi_scale * state->ui.user_scale;
+}
+
 static inline void reset_scale(AppState *state) {
     sexp default_symbol = sexp_intern(state->chibi.ctx, "default-scale", -1);
     sexp val = sexp_env_ref(state->chibi.ctx, state->chibi.env, default_symbol,
                             sexp_make_flonum(state->chibi.ctx, 1.0));
-    state->ui.scale_factor = sexp_flonum_value(val);
+    state->ui.user_scale = sexp_flonum_value(val);
+    ui_recompute_scale(state);
 }
 
 static inline void increase_scale(AppState *state) {
-    state->ui.scale_factor *= 1.1;
+    state->ui.user_scale *= 1.1;
+    ui_recompute_scale(state);
 }
 
 static inline void decrease_scale(AppState *state) {
-    state->ui.scale_factor /= 1.1;
+    state->ui.user_scale /= 1.1;
+    ui_recompute_scale(state);
 }
 
 static inline void reset_buffer_scale(AppState *state, Buffer *buf) {

--- a/src/event.c
+++ b/src/event.c
@@ -104,6 +104,9 @@ static bool pane_hit_to_buf_pos(AppState *state, Pane *pane,
 SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event) {
     AppState *state = (AppState*) appstate;
 
+    // Convert mouse/touch coordinates from window space to render (pixel) space
+    SDL_ConvertEventToRenderCoordinates(state->rendererData.renderer, event);
+
     switch (event->type) {
     case SDL_EVENT_USER:
         if (event->user.code == CURSOR_FLASH_EVENT) {
@@ -378,12 +381,24 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event) {
         }
         break;
 
-    case SDL_EVENT_WINDOW_RESIZED:
+    case SDL_EVENT_WINDOW_RESIZED: {
         state->needs_redraw = true;
         int width, height;
-        SDL_GetWindowSize(state->window, &width, &height);
+        SDL_GetWindowSizeInPixels(state->window, &width, &height);
         Clay_SetLayoutDimensions((Clay_Dimensions) {(float) width, (float) height});
         break;
+    }
+
+    case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED: {
+        float dpi = SDL_GetWindowDisplayScale(state->window);
+        state->ui.dpi_scale = (dpi > 0.0f) ? dpi : 1.0f;
+        state->ui.scale_factor = state->ui.dpi_scale * state->ui.user_scale;
+        int width, height;
+        SDL_GetWindowSizeInPixels(state->window, &width, &height);
+        Clay_SetLayoutDimensions((Clay_Dimensions) {(float) width, (float) height});
+        state->needs_redraw = true;
+        break;
+    }
 
     case SDL_EVENT_QUIT:
         return SDL_APP_SUCCESS;

--- a/src/init.c
+++ b/src/init.c
@@ -25,7 +25,8 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[]) {
     }
     *appstate = state;
 
-    if (!SDL_CreateWindowAndRenderer("sev", 800, 600, SDL_WINDOW_RESIZABLE,
+    if (!SDL_CreateWindowAndRenderer("sev", 800, 600,
+                                     SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY,
                                      &state->window, &state->rendererData.renderer)) {
         SDL_Log("Failed to create window and renderer = %s", SDL_GetError());
         return SDL_APP_FAILURE;
@@ -97,7 +98,10 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[]) {
         return SDL_APP_FAILURE;
     }
 
-    state->ui.scale_factor = 1.0;
+    float dpi = SDL_GetWindowDisplayScale(state->window);
+    state->ui.dpi_scale = (dpi > 0.0f) ? dpi : 1.0f;
+    state->ui.user_scale = 1.0f;
+    state->ui.scale_factor = state->ui.dpi_scale * state->ui.user_scale;
     scheme_init(state);
 
     if (!buffer_list_init()) {

--- a/src/state.h
+++ b/src/state.h
@@ -109,7 +109,9 @@ typedef struct UIState {
     VarTable palette_table;   // palette-symbol -> Color
     CachedRoles roles;        // pre-interned role symbols
     CachedSymbols symbols;    // pre-interned misc symbols for theme resolution
-    float scale_factor;       // global scaling factor
+    float dpi_scale;          // display pixel density (e.g. 2.0 on retina)
+    float user_scale;         // user zoom level (default from Scheme)
+    float scale_factor;       // effective scale = dpi_scale * user_scale
 } UIState;
 
 #define MINIBUF_PROMPT_MAX 256


### PR DESCRIPTION
Requests a high pixel density backbuffer from SDL3 and feeds Clay pixel dimensions instead of logical window size. Separates DPI scale from user zoom into `dpi_scale` and `user_scale` (existing `scale_factor` becomes the product of both), so Scheme zoom commands don't interfere with display density.

Handles `SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED` so it adapts live when moving between displays. Works with fractional scaling (1.5x, 1.75x, etc).

No changes to any display/rendering code since everything already reads `scale_factor`.