### PR TITLE
[README] Fix aspect ratio of hero images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Sev is an Emacs-like, Vim-like graphical text editor, built from scratch using [
 ## Screenshots
 
 <figure>
-  <img width="3778" height="2047" alt="image" src="https://github.com/user-attachments/assets/5b595e0d-571f-4b2d-9ecd-ce4916cd9e6a" />
+  <img width="3778" alt="image" src="https://github.com/user-attachments/assets/5b595e0d-571f-4b2d-9ecd-ce4916cd9e6a" />
   <figcaption>Panes, tabs and syntax highlighting.</figcaption>
 </figure>
 
 <figure>
-  <img width="3778" height="2047" alt="image" src="https://github.com/user-attachments/assets/84412c21-f423-4884-9566-360ca90f9b32" />  
+  <img width="3778" alt="image" src="https://github.com/user-attachments/assets/84412c21-f423-4884-9566-360ca90f9b32" />  
   <figcaption>Welcome screen and command palette.</figcaption>
 </figure>
 
 <figure>
-  <img width="3778" height="2047" alt="image" src="https://github.com/user-attachments/assets/87ed1065-f070-4aa8-b271-566000c7153c" />
+  <img width="3778" alt="image" src="https://github.com/user-attachments/assets/87ed1065-f070-4aa8-b271-566000c7153c" />
   <figcaption>Theme picker with theme previews.</figcaption>
 </figure>
 


### PR DESCRIPTION
Just a tiny change to fix the stretched aspect ratio of the embedded hero images in the README.

**before**
<img width="2228" height="1864" alt="Screenshot 2026-04-19 at 10 44 16 am" src="https://github.com/user-attachments/assets/3b1f80d5-0868-4abe-bc7d-5d83b8efc785" />

**after**
<img width="2166" height="1418" alt="Screenshot 2026-04-19 at 10 44 56 am" src="https://github.com/user-attachments/assets/04031126-a6fe-4adf-ac16-81c55763d1d0" />
